### PR TITLE
Switch backend YouTube fallback to pytube

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 from flask import Flask, request, Response, stream_with_context, jsonify, send_from_directory
 from flask_cors import CORS
 from yt_dlp import YoutubeDL
-from pytubefix import YouTube
-from pytubefix.cli import on_progress
+from pytube import YouTube
+from pytube.cli import on_progress
 import requests
 import re
 import os
@@ -108,9 +108,9 @@ def download():
         print(f"yt-dlp failed: {e}")
         # Continue to fallback
 
-    # 2. Fallback to pytubefix
+    # 2. Fallback to pytube
     try:
-        print(f"Attempting pytubefix fallback for {url}")
+        print(f"Attempting pytube fallback for {url}")
         yt = YouTube(url, on_progress_callback=on_progress)
         
         if type_ == 'audio':

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ flask-cors
 yt-dlp
 requests
 gunicorn
-pytubefix
+pytube

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 from flask import Flask, request, Response, stream_with_context, jsonify
 from flask_cors import CORS
-from pytubefix import YouTube
+from pytube import YouTube
 import requests
 import re
 import os
@@ -23,7 +23,7 @@ def download():
         return jsonify({"error": "Missing URL"}), 400
 
     try:
-        # Use pytubefix for better reliability
+        # Use pytube as fallback stream extractor
         yt = YouTube(url)
         
         # Select the best stream based on type


### PR DESCRIPTION
### Motivation
- Replace the third-party `pytubefix` package with the official `pytube` package so the backend uses the upstream extractor and simplifies dependency management.

### Description
- Replaced `pytubefix` imports with `pytube` in `main.py` and `server.py` and updated related fallback logging/comments to reference `pytube`.
- Updated `requirements.txt` to install `pytube` instead of `pytubefix`.
- Kept existing yt-dlp first-stage logic and retained the same streaming proxy and response header behavior.

### Testing
- Ran `python -m py_compile main.py server.py app.py` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699783edd8548330a431e8d77775971f)