### PR TITLE
Add Dockerfile and guard optional pytube fallback to prevent startup failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-bookworm
+
+WORKDIR /app
+
+# Install Python and pip for backend runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies first for better layer caching
+COPY package.json ./
+COPY requirements.txt ./
+RUN npm install && pip3 install --no-cache-dir -r requirements.txt
+
+# Copy source and build frontend assets
+COPY . .
+RUN npm run build
+
+ENV PORT=5000
+EXPOSE 5000
+
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "main:app"]

--- a/main.py
+++ b/main.py
@@ -1,8 +1,12 @@
 from flask import Flask, request, Response, stream_with_context, jsonify, send_from_directory
 from flask_cors import CORS
 from yt_dlp import YoutubeDL
-from pytube import YouTube
-from pytube.cli import on_progress
+try:
+    from pytube import YouTube
+    from pytube.cli import on_progress
+except Exception:
+    YouTube = None
+    on_progress = None
 import requests
 import re
 import os
@@ -108,7 +112,10 @@ def download():
         print(f"yt-dlp failed: {e}")
         # Continue to fallback
 
-    # 2. Fallback to pytube
+    # 2. Fallback to pytube (if available in runtime)
+    if YouTube is None:
+        return jsonify({"error": "Download fallback unavailable: pytube is not installed on server."}), 503
+
     try:
         print(f"Attempting pytube fallback for {url}")
         yt = YouTube(url, on_progress_callback=on_progress)

--- a/server.py
+++ b/server.py
@@ -1,6 +1,9 @@
 from flask import Flask, request, Response, stream_with_context, jsonify
 from flask_cors import CORS
-from pytube import YouTube
+try:
+    from pytube import YouTube
+except Exception:
+    YouTube = None
 import requests
 import re
 import os
@@ -21,6 +24,9 @@ def download():
     
     if not url:
         return jsonify({"error": "Missing URL"}), 400
+
+    if YouTube is None:
+        return jsonify({"error": "pytube is not installed on server."}), 503
 
     try:
         # Use pytube as fallback stream extractor


### PR DESCRIPTION
### Motivation
- The site failed to serve in some deployments because the frontend wasn't built and the Python/Node runtime/startup were not packaged for Docker.
- Importing `pytube` at module load caused the app to crash when the package was not available in the runtime, preventing health checks and startup.
- The download fallback path needed clearer runtime handling so the server returns a controlled error instead of crashing.

### Description
- Add a production `Dockerfile` that installs Node and Python runtimes, installs Node and pip dependencies, builds the Vite frontend, and starts Gunicorn on port `5000`.
- Make `pytube` imports optional with a `try/except` in `main.py` so the app can boot when `pytube` is not installed and set `on_progress`/`YouTube` to `None` as needed.
- Add runtime guards that return a `503` JSON response when yt-dlp fails and `pytube` is not installed instead of raising an import error, in both `main.py` and `server.py`.
- Keep the existing yt-dlp-first download flow and proxy streaming behavior while making the fallback explicit and failure-safe.

### Testing
- Ran `npm run build` and the Vite production build completed successfully.
- Verified Python syntax with `python3 -m py_compile main.py server.py app.py`, which succeeded.
- Launched the app with `gunicorn -b 127.0.0.1:5001 main:app` and confirmed the health endpoint `curl -sf http://127.0.0.1:5001/health` returned success.
- Attempted `pip3 install -r requirements.txt` but installation of `pytube` failed due to the environment proxy (package fetch error), which is why the optional import guards were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69978641005c83308103c0ff2b784c5c)