### PR TITLE
Fix cross-origin download failures from mirror URLs

### DIFF
--- a/components/DownloadSection.tsx
+++ b/components/DownloadSection.tsx
@@ -73,14 +73,16 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
           link.click();
           document.body.removeChild(link);
         } else {
-          // Third-party temporary URLs can fail/resume poorly. Fetch as Blob first for reliability.
-          const response = await fetch(result.url);
-          if (!response.ok) throw new Error('Mirror download is temporarily unavailable');
-
-          const blob = await response.blob();
-          const blobUrl = window.URL.createObjectURL(blob);
-          downloadBlob(blobUrl, filename);
-          window.URL.revokeObjectURL(blobUrl);
+          // Third-party media hosts often block CORS, so blob fetching can fail.
+          // Use a direct navigation fallback that still allows the browser to download the file.
+          const link = document.createElement('a');
+          link.href = result.url;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+          link.download = filename;
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
         }
       } else {
         setError(result.error || 'Failed to generate link');


### PR DESCRIPTION
### Motivation
- Third-party mirror URLs frequently block cross-origin `fetch` calls which caused the previous blob-based download path to fail and surface a generic connection error instead of allowing the browser to download the file.

### Description
- For non-same-origin download URLs, replaced the `fetch(...).blob()` flow in `components/DownloadSection.tsx` with a direct anchor navigation created via JavaScript that opens the mirror URL in a new tab and uses `rel="noopener noreferrer"` and the `download` attribute, while keeping same-origin backend streaming unchanged.

### Testing
- Ran `npm run build` and the production build completed successfully with Vite (no build errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d559d6f08330871b070894f683fe)