### PR TITLE
Ensure frontend is built on startup and bind Gunicorn to platform PORT

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,10 +10,27 @@ except Exception:
 import requests
 import re
 import os
+import subprocess
 
 # Determine absolute path to dist folder
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DIST_DIR = os.path.join(BASE_DIR, 'dist')
+
+
+def ensure_frontend_build():
+    """Build the frontend if dist/index.html is missing."""
+    index_path = os.path.join(DIST_DIR, 'index.html')
+    if os.path.exists(index_path):
+        return
+
+    print("dist/index.html not found. Attempting to build frontend...")
+    try:
+        subprocess.run(["npm", "run", "build"], cwd=BASE_DIR, check=True)
+    except Exception as build_err:
+        print(f"Frontend build failed: {build_err}")
+
+
+ensure_frontend_build()
 
 # Initialize Flask App serving the 'dist' folder built by Vite
 app = Flask(__name__, static_folder=DIST_DIR, static_url_path='')

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -12,4 +12,4 @@ cmds = ["npm install", "pip install -r requirements.txt"]
 cmds = ["npm run build"]
 
 [start]
-cmd = "gunicorn main:app"
+cmd = "gunicorn -b 0.0.0.0:${PORT:-5000} main:app"


### PR DESCRIPTION
### Motivation
- The server returned `Index not found` when frontend assets were not built prior to startup, preventing the web UI from being served. 
- Deployments can fail to receive traffic when Gunicorn isn't bound to the platform-provided `PORT`, so a dynamic bind is needed.

### Description
- Add `ensure_frontend_build()` to `main.py` which checks for `dist/index.html` and runs `npm run build` via `subprocess.run` if missing. 
- Call `ensure_frontend_build()` before initializing the Flask `app` so the `dist` assets are available for static serving. 
- Update `nixpacks.toml` start command to `gunicorn -b 0.0.0.0:${PORT:-5000} main:app` so Gunicorn binds to the runtime `PORT` when provided.

### Testing
- Ran `npm run build` which completed successfully and produced `dist/index.html`. 
- Executed a Flask test client GET to `/` before the change which returned `404` (observed failure mode). 
- Executed a Flask test client GET to `/` after the change which returned `200` with HTML content (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d81abf288330a9ff843db84022bb)