### PR TITLE
Show AI summary panel only when toggle is enabled; ensure frontend build and bind Gunicorn to PORT

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -113,25 +113,19 @@ const App: React.FC = () => {
             </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 md:gap-6 lg:gap-8">
-              <div className="lg:col-span-1 space-y-4 md:space-y-6">
+              <div className={`${isAiEnabled ? 'lg:col-span-1' : 'lg:col-span-3'} space-y-4 md:space-y-6`}>
                 <VideoPreview metadata={videoData} />
                 <DownloadSection metadata={videoData} />
               </div>
 
-              <div className="lg:col-span-2">
-                {isAiEnabled ? (
+              {isAiEnabled && (
+                <div className="lg:col-span-2">
                   <AiInsights
                     analysis={aiAnalysis ?? { summary: '', topics: [], suggestedQuestions: [] }}
                     isLoading={isAiLoading || !aiAnalysis}
                   />
-                ) : (
-                  <div className="bg-gray-900/50 rounded-3xl border border-white/10 min-h-[220px] md:min-h-[320px] p-6 md:p-8 flex items-center justify-center text-center">
-                    <p className="text-gray-300 max-w-md">
-                      AI summaries are currently turned off to keep things faster. Tap the <span className="text-indigo-300 font-semibold">AI Summary</span> toggle to generate one.
-                    </p>
-                  </div>
-                )}
-              </div>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/main.py
+++ b/main.py
@@ -10,10 +10,27 @@ except Exception:
 import requests
 import re
 import os
+import subprocess
 
 # Determine absolute path to dist folder
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DIST_DIR = os.path.join(BASE_DIR, 'dist')
+
+
+def ensure_frontend_build():
+    """Build the frontend if dist/index.html is missing."""
+    index_path = os.path.join(DIST_DIR, 'index.html')
+    if os.path.exists(index_path):
+        return
+
+    print("dist/index.html not found. Attempting to build frontend...")
+    try:
+        subprocess.run(["npm", "run", "build"], cwd=BASE_DIR, check=True)
+    except Exception as build_err:
+        print(f"Frontend build failed: {build_err}")
+
+
+ensure_frontend_build()
 
 # Initialize Flask App serving the 'dist' folder built by Vite
 app = Flask(__name__, static_folder=DIST_DIR, static_url_path='')

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -12,4 +12,4 @@ cmds = ["npm install", "pip install -r requirements.txt"]
 cmds = ["npm run build"]
 
 [start]
-cmd = "gunicorn main:app"
+cmd = "gunicorn -b 0.0.0.0:${PORT:-5000} main:app"


### PR DESCRIPTION
### Motivation
- Prevent the AI insights UI from occupying space or showing a placeholder when the user has the AI Summary toggle off. 
- Ensure the frontend assets exist at runtime so the Flask app can serve the UI without returning "Index not found". 
- Bind Gunicorn to the platform-provided port so deployments receive traffic when a `PORT` is supplied.

### Description
- Update `App.tsx` to render the `AiInsights` panel only when `isAiEnabled` is true and expand the preview/download column to `lg:col-span-3` while AI is off, removing the previous placeholder block. 
- Add `ensure_frontend_build()` to `main.py` which checks for `dist/index.html` and runs `npm run build` via `subprocess.run` if missing before Flask app initialization. 
- Update `nixpacks.toml` `start` command to `gunicorn -b 0.0.0.0:${PORT:-5000} main:app` so Gunicorn binds to the runtime `PORT` when provided.

### Testing
- Ran `npm run build` which completed successfully and produced `dist/index.html` (passed). 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed it became ready (passed). 
- Executed a Playwright script that loads the app, submits a video URL, verifies the AI Summary is off visually, and saved a screenshot artifact (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d81abf288330a9ff843db84022bb)