### PR TITLE
Improve download backend availability checks to avoid stale fallback links

### DIFF
--- a/services/downloadService.ts
+++ b/services/downloadService.ts
@@ -20,16 +20,20 @@ const COBALT_INSTANCES = [
 
 let cachedBackendState: { available: boolean; checkedAt: number } | null = null;
 const BACKEND_CACHE_TTL_MS = 30_000;
+const BACKEND_FAILURE_CACHE_TTL_MS = 5_000;
 
 const isBackendAvailable = async (apiUrl: string): Promise<boolean> => {
   const now = Date.now();
-  if (cachedBackendState && now - cachedBackendState.checkedAt < BACKEND_CACHE_TTL_MS) {
-    return cachedBackendState.available;
+  if (cachedBackendState) {
+    const ttl = cachedBackendState.available ? BACKEND_CACHE_TTL_MS : BACKEND_FAILURE_CACHE_TTL_MS;
+    if (now - cachedBackendState.checkedAt < ttl) {
+      return cachedBackendState.available;
+    }
   }
 
   try {
     const controller = new AbortController();
-    const id = setTimeout(() => controller.abort(), 1500);
+    const id = setTimeout(() => controller.abort(), 5000);
     const health = await fetch(`${apiUrl}/health`, { signal: controller.signal });
     clearTimeout(id);
 


### PR DESCRIPTION
### Motivation
- Reduce false-negative backend health checks that send users to temporary third‑party download mirrors instead of the local backend.
- Avoid long-lived cached negative results so the UI recovers quickly from transient backend blips.
- Make backend probes more tolerant of slow responses to reduce unnecessary fallback behavior.

### Description
- Updated `services/downloadService.ts` to add a `BACKEND_FAILURE_CACHE_TTL_MS` (5_000 ms) and use a shorter TTL for failed health checks while keeping successful checks cached for `BACKEND_CACHE_TTL_MS` (30_000 ms). 
- Changed the health-check abort timeout from `1500` ms to `5000` ms to allow slower-but-healthy backends to respond before being marked unavailable.
- Adjusted cache logic to choose the appropriate TTL based on the last known `available` state so transient failures expire quickly.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999dbb345348330871ae260dbb3f077)