### PR TITLE
Use official yt-dlp GitHub source for download pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 * **Frontend**: [React.js](https://reactjs.org/) with **TypeScript** (TSX) for robust type-safety.
 * **Styling**: **Tailwind CSS** using a modern glassmorphism design language.
 * **Backend**: **Node.js** & **Express** for handling high-concurrency requests.
-* **Media Engine**: Integrated with **ytdl-core** and **FFmpeg** for seamless media manipulation.
+* **Media Engine**: Integrated with **yt-dlp** and **FFmpeg** for resilient media extraction and processing.
 * **AI Integration**: RESTful communication with OpenAI (GPT-4) or Anthropic (Claude) API.
 
 ---
@@ -102,7 +102,7 @@ npm start
 ### ⚠️ Known Issues
 
 * **Downloader Stability**: Due to frequent updates to YouTube's infrastructure, the video download and audio extraction features may occasionally fail.
-* **Status**: Currently, the **Thumbnail Extractor** and **AI Summarizer** are fully functional. We are investigating updates to the `ytdl` core to resolve download stream issues.
+* **Status**: Currently, the **Thumbnail Extractor** and **AI Summarizer** are fully functional. We use the actively maintained `yt-dlp` extractor stack to keep download support stable as YouTube changes.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 flask
 flask-cors
-yt-dlp
+yt-dlp @ git+https://github.com/yt-dlp/yt-dlp.git
 requests
 gunicorn
-pytube


### PR DESCRIPTION
### Motivation

- Stabilize the media downloader by relying on the actively maintained `yt-dlp` extractor instead of legacy fallbacks. 
- Ensure the backend returns directly streamable media URLs with correct container-aware filenames and content-types.

### Description

- Reworked `/download` flow in `main.py` to use `yt_dlp.YoutubeDL` exclusively and removed the `pytube` fallback path. 
- Adjusted `yt-dlp` options and format selection to prefer streamable video/audio formats and added a 502 error when no downloadable URL is returned. 
- Set filename extension and `Content-Type` based on the actual `yt-dlp` `ext` metadata (handles `webm` audio vs `mp4` containers). 
- Pinned `yt-dlp` in `requirements.txt` to the official GitHub repository (`yt-dlp @ git+https://github.com/yt-dlp/yt-dlp.git`). 
- Updated `README.md` to reflect the switch to `yt-dlp` as the media engine and the extractor status.

### Testing

- Ran Python static check with `python -m py_compile main.py server.py app.py`, which completed successfully. 
- Built the frontend with `npm run build`, which completed successfully and produced `dist` artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999de9b91208330a82b53694d803be8)