### PR TITLE
Open third-party media URLs directly instead of forcing anchor `download`

### DIFF
--- a/components/DownloadSection.tsx
+++ b/components/DownloadSection.tsx
@@ -73,16 +73,12 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
           link.click();
           document.body.removeChild(link);
         } else {
-          // Third-party media hosts often block CORS, so blob fetching can fail.
-          // Use a direct navigation fallback that still allows the browser to download the file.
-          const link = document.createElement('a');
-          link.href = result.url;
-          link.target = '_blank';
-          link.rel = 'noopener noreferrer';
-          link.download = filename;
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
+          // Third-party URLs are often signed and can fail when forced through the
+          // `download` attribute. Open the source URL directly instead.
+          const popup = window.open(result.url, '_blank', 'noopener,noreferrer');
+          if (!popup) {
+            window.location.href = result.url;
+          }
         }
       } else {
         setError(result.error || 'Failed to generate link');


### PR DESCRIPTION
### Motivation
- Some signed/temporary third-party media URLs fail when the app forces a cross-origin download via an anchor `download` attribute, causing errors like “File wasn’t available on site.”

### Description
- Updated `components/DownloadSection.tsx` to open external (non-same-origin) `result.url` with `window.open(...)` instead of creating an anchor with `download` and clicking it.
- Added a popup-blocker fallback that navigates the current tab to the media URL when `window.open` is blocked by the browser.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e0c6837883308298d2a636bf54bb)