### PR TITLE
Probe backend before download and fall back to Cobalt mirrors

### DIFF
--- a/components/DownloadSection.tsx
+++ b/components/DownloadSection.tsx
@@ -73,16 +73,12 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
           link.click();
           document.body.removeChild(link);
         } else {
-          // Third-party media hosts often block CORS, so blob fetching can fail.
-          // Use a direct navigation fallback that still allows the browser to download the file.
-          const link = document.createElement('a');
-          link.href = result.url;
-          link.target = '_blank';
-          link.rel = 'noopener noreferrer';
-          link.download = filename;
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
+          // Third-party URLs are often signed and can fail when forced through the
+          // `download` attribute. Open the source URL directly instead.
+          const popup = window.open(result.url, '_blank', 'noopener,noreferrer');
+          if (!popup) {
+            window.location.href = result.url;
+          }
         }
       } else {
         setError(result.error || 'Failed to generate link');

--- a/main.py
+++ b/main.py
@@ -76,6 +76,7 @@ def download():
     url = request.args.get('url')
     type_ = request.args.get('type', 'video')
     quality = request.args.get('quality', '1080p')
+    probe = request.args.get('probe') == '1'
     
     if not url:
         return jsonify({"error": "Missing URL"}), 400
@@ -106,6 +107,14 @@ def download():
                 ext = info.get('ext', 'mp4' if type_ == 'video' else 'm4a')
                 filename_ext = 'mp4' if type_ == 'video' else ext
                 filename = f"{sanitize_filename(title)}.{filename_ext}"
+
+                if probe:
+                    return jsonify({
+                        "ok": True,
+                        "filename": filename,
+                        "ext": filename_ext,
+                    })
+
                 if type_ == 'video':
                     content_type = 'video/mp4'
                 else:


### PR DESCRIPTION
### Motivation
- Backend health checks alone could still hand the client a `/download` URL that fails for a specific video when `yt-dlp` cannot extract a media URL, resulting in a broken browser download. 
- Avoid sending the browser a failing streaming URL by doing a lightweight backend probe first and using public Cobalt mirrors if the probe fails. 
- Ensure third-party (signed) URLs are opened in a way that doesn't break when the `download` attribute is applied.

### Description
- Added a `probe=1` mode to the backend `/download` endpoint in `main.py` which returns a small JSON payload (`ok`, `filename`, `ext`) when a media URL is resolvable without starting the full stream. 
- Implemented `backendDownloadProbe(...)` in `services/downloadService.ts` that calls the backend probe and times out after 8s. 
- Updated `processDownload` to call the probe when the backend is available and only return a backend `/download` URL when the probe succeeds, otherwise falling back to the existing Cobalt mirror selection flow. 
- Updated `components/DownloadSection.tsx` to open third-party (non-same-origin) media URLs with `window.open(...)` and fall back to `window.location.href` when popups are blocked to avoid forcing a `download` attribute on signed URLs.

### Testing
- Ran `npm run build` which produced a successful production build (Vite build completed). 
- Ran `python -m py_compile main.py` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e0c6837883308298d2a636bf54bb)