### PR TITLE
Improve downloader resilience and front-end load performance

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import { Header } from './components/Header';
 import { UrlInput } from './components/UrlInput';
 import { VideoPreview } from './components/VideoPreview';
-import { AiInsights } from './components/AiInsights';
 import { DownloadSection } from './components/DownloadSection';
 import { fetchVideoMetadata } from './services/youtubeService';
-import { analyzeVideoContext } from './services/geminiService';
 import { VideoMetadata, AiAnalysisResult } from './types';
-import { AlertCircle, ArrowLeft } from 'lucide-react';
+import { AlertCircle, ArrowLeft, Loader2 } from 'lucide-react';
+
+const AiInsights = React.lazy(() => import('./components/AiInsights').then((module) => ({ default: module.AiInsights })));
 
 const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -21,6 +21,7 @@ const App: React.FC = () => {
   const runAiAnalysis = async (metadata: VideoMetadata) => {
     setIsAiLoading(true);
     try {
+      const { analyzeVideoContext } = await import('./services/geminiService');
       const analysis = await analyzeVideoContext(
         metadata.title,
         metadata.author_name,
@@ -120,10 +121,19 @@ const App: React.FC = () => {
 
               {isAiEnabled && (
                 <div className="lg:col-span-2">
-                  <AiInsights
-                    analysis={aiAnalysis ?? { summary: '', topics: [], suggestedQuestions: [] }}
-                    isLoading={isAiLoading || !aiAnalysis}
-                  />
+                  <Suspense
+                    fallback={
+                      <div className="h-full min-h-[260px] rounded-3xl border border-white/10 bg-gray-900/40 flex items-center justify-center text-gray-300 gap-2">
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        <span>Loading AI module…</span>
+                      </div>
+                    }
+                  >
+                    <AiInsights
+                      analysis={aiAnalysis ?? { summary: '', topics: [], suggestedQuestions: [] }}
+                      isLoading={isAiLoading || !aiAnalysis}
+                    />
+                  </Suspense>
                 </div>
               )}
             </div>

--- a/components/DownloadSection.tsx
+++ b/components/DownloadSection.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { VideoMetadata } from '../types';
-import { Download, FileVideo, Music, Image as ImageIcon, Check, Loader2, ExternalLink, AlertCircle, ShieldCheck } from 'lucide-react';
+import { Download, FileVideo, Music, Image as ImageIcon, Loader2, AlertCircle, ShieldCheck } from 'lucide-react';
 import { extractVideoId } from '../services/youtubeService';
 import { processDownload, downloadBlob } from '../services/downloadService';
 
@@ -17,7 +17,7 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
 
   const videoId = extractVideoId(metadata.url);
 
-  const downloadFormats = {
+  const downloadFormats = useMemo(() => ({
     video: [
       { label: '1080p', ext: 'mp4', sub: 'High Definition', icon: FileVideo, quality: '1080p' },
       { label: '720p', ext: 'mp4', sub: 'HD Ready', icon: FileVideo, quality: '720p' },
@@ -30,9 +30,9 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
       { label: 'Max Res', ext: 'jpg', sub: '1920x1080', icon: ImageIcon, url: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg` },
       { label: 'High Quality', ext: 'jpg', sub: '480x360', icon: ImageIcon, url: `https://img.youtube.com/vi/${videoId}/hqdefault.jpg` },
     ]
-  };
+  }), [videoId]);
 
-  const handleDownload = async (item: any) => {
+  const handleDownload = async (item: { label: string; quality?: string; url?: string; }) => {
     setProcessing(item.label);
     setError(null);
     
@@ -54,7 +54,7 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
       }
 
       // 2. Handle Video/Audio
-      const result = await processDownload(metadata.url, activeTab as 'video' | 'audio', item.quality);
+      const result = await processDownload(metadata.url, activeTab as 'video' | 'audio', item.quality ?? '1080p');
       
       if (result.success && result.url) {
         const safeTitle = metadata.title.replace(/[\\/*?:"<>|]/g, '').trim().slice(0, 60) || 'download';

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import requests
 import re
 import os
 import subprocess
+import random
 
 # Determine absolute path to dist folder
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -26,6 +27,18 @@ def ensure_frontend_build():
 
 ensure_frontend_build()
 
+COBALT_INSTANCES = [
+    'https://cobalt.steamodded.com/api/json',
+    'https://dl.khub.ky/api/json',
+    'https://api.succoon.com/api/json',
+    'https://cobalt.rayrad.net/api/json',
+    'https://cobalt.slpy.one/api/json',
+    'https://cobalt.soapless.dev/api/json',
+    'https://api.wuk.sh/api/json',
+    'https://co.wuk.sh/api/json',
+    'https://api.cobalt.tools/api/json',
+]
+
 # Initialize Flask App serving the 'dist' folder built by Vite
 app = Flask(__name__, static_folder=DIST_DIR, static_url_path='')
 CORS(app)
@@ -42,7 +55,7 @@ def serve_assets(path):
 
 @app.route('/<path:path>')
 def catch_all(path):
-    if path.startswith('api') or path in ['health', 'download']:
+    if path.startswith('api') or path in ['health', 'download', 'fallback-download']:
         return "Not Found", 404
     
     full_path = os.path.join(app.static_folder, path)
@@ -57,6 +70,60 @@ def catch_all(path):
 @app.route('/health', methods=['GET'])
 def health():
     return jsonify({"status": "ok", "service": "yt-dlp-downloader"})
+
+
+def resolve_with_cobalt(url, type_, quality):
+    v_quality = '1080' if quality == '1080p' else '720' if quality == '720p' else '480'
+    payload = {
+        'url': url,
+        'vQuality': v_quality,
+        'isAudioOnly': type_ == 'audio',
+        'aFormat': 'mp3' if type_ == 'audio' else None,
+        'filenamePattern': 'basic',
+    }
+
+    mirrors = COBALT_INSTANCES.copy()
+    random.shuffle(mirrors)
+
+    for api in mirrors:
+        try:
+            response = requests.post(
+                api,
+                json=payload,
+                headers={'Accept': 'application/json', 'Content-Type': 'application/json'},
+                timeout=8,
+            )
+            if not response.ok:
+                continue
+
+            data = response.json()
+            status = data.get('status')
+            if status in ('stream', 'redirect') and data.get('url'):
+                return data.get('url')
+
+            picker = data.get('picker') or []
+            if status == 'picker' and len(picker) > 0 and picker[0].get('url'):
+                return picker[0].get('url')
+        except Exception:
+            continue
+
+    return None
+
+
+@app.route('/fallback-download', methods=['GET'])
+def fallback_download():
+    url = request.args.get('url')
+    type_ = request.args.get('type', 'video')
+    quality = request.args.get('quality', '1080p')
+
+    if not url:
+        return jsonify({"ok": False, "error": "Missing URL"}), 400
+
+    candidate = resolve_with_cobalt(url, type_, quality)
+    if candidate:
+        return jsonify({"ok": True, "url": candidate})
+
+    return jsonify({"ok": False, "error": "All download servers are busy. Please try another video or check back later."}), 503
 
 def sanitize_filename(name):
     return re.sub(r'[\\/*?:"<>|]', "", name)

--- a/services/downloadService.ts
+++ b/services/downloadService.ts
@@ -117,7 +117,20 @@ export const processDownload = async (
       return { success: true, url: downloadUrl };
     }
 
-    console.warn('Backend is up but cannot fetch this media right now, trying public mirrors...');
+    console.warn('Backend yt-dlp is up but cannot fetch this media right now, trying server-assisted fallback...');
+
+    try {
+      const fallbackUrl = `${apiUrl}/fallback-download?url=${encodeURIComponent(url)}&type=${type}&quality=${quality}`;
+      const fallbackResponse = await fetch(fallbackUrl);
+      if (fallbackResponse.ok) {
+        const payload = await fallbackResponse.json();
+        if (payload?.ok && payload?.url) {
+          return { success: true, url: payload.url };
+        }
+      }
+    } catch (_err) {
+      // Ignore and continue to direct client mirror fallback.
+    }
   } else {
     console.warn('Backend not reachable, trying public mirrors...');
   }


### PR DESCRIPTION
### Motivation
- The backend `yt-dlp` probe can succeed but still fail to produce a usable stream, leaving users with the generic “servers busy” error; a server-side mirror resolver improves reliability.
- Client-side Cobalt mirror probing is useful but can be slow or fail in some environments, so a server-assisted fallback reduces latency and improves success rate.
- The AI features and their dependencies increase initial bundle size, so lazy-loading them when AI mode is enabled improves startup performance and perceived speed.
- Minor render optimizations in the download panel reduce unnecessary work on every render.

### Description
- Added a server endpoint `GET /fallback-download` (in `main.py`) that iterates shuffled Cobalt mirror APIs and returns the first usable `stream`/`redirect` or `picker` URL, with an 8s timeout per mirror.
- Wired the frontend download flow (`services/downloadService.ts`) to call the new `/fallback-download` if the local `yt-dlp` probe indicates the backend is up but cannot fetch the media, before falling back to client-side mirror probing.
- Split and lazy-load AI code in the UI by making `AiInsights` a `React.lazy` chunk and dynamically importing `analyzeVideoContext` from `geminiService` only when AI is requested, wrapped in `Suspense` with a loader (in `App.tsx`).
- Memoized `downloadFormats` in `components/DownloadSection.tsx` with `useMemo` and tightened the download handler typing, and defaulted missing quality to `1080p` to avoid undefined behavior.

### Testing
- Ran `npm run build` and verified the production build completed successfully and produced a smaller main bundle with a separate `AiInsights` chunk (build completed without errors).
- Ran `python -m py_compile main.py` and confirmed the Python server file compiles without syntax errors.
- Started the dev server (`npm run dev`) and captured a UI screenshot via Playwright to validate the app renders and the lazy-loaded AI component path shows the loader when enabled.
- All automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f1a2d5048327baa0f4f537ae853c)