### PR TITLE
Proxy fallback downloads through backend and reduce probe timeout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import { Header } from './components/Header';
 import { UrlInput } from './components/UrlInput';
 import { VideoPreview } from './components/VideoPreview';
-import { AiInsights } from './components/AiInsights';
 import { DownloadSection } from './components/DownloadSection';
 import { fetchVideoMetadata } from './services/youtubeService';
-import { analyzeVideoContext } from './services/geminiService';
 import { VideoMetadata, AiAnalysisResult } from './types';
-import { AlertCircle, ArrowLeft } from 'lucide-react';
+import { AlertCircle, ArrowLeft, Loader2 } from 'lucide-react';
+
+const AiInsights = React.lazy(() => import('./components/AiInsights').then((module) => ({ default: module.AiInsights })));
 
 const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -21,6 +21,7 @@ const App: React.FC = () => {
   const runAiAnalysis = async (metadata: VideoMetadata) => {
     setIsAiLoading(true);
     try {
+      const { analyzeVideoContext } = await import('./services/geminiService');
       const analysis = await analyzeVideoContext(
         metadata.title,
         metadata.author_name,
@@ -120,10 +121,19 @@ const App: React.FC = () => {
 
               {isAiEnabled && (
                 <div className="lg:col-span-2">
-                  <AiInsights
-                    analysis={aiAnalysis ?? { summary: '', topics: [], suggestedQuestions: [] }}
-                    isLoading={isAiLoading || !aiAnalysis}
-                  />
+                  <Suspense
+                    fallback={
+                      <div className="h-full min-h-[260px] rounded-3xl border border-white/10 bg-gray-900/40 flex items-center justify-center text-gray-300 gap-2">
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        <span>Loading AI module…</span>
+                      </div>
+                    }
+                  >
+                    <AiInsights
+                      analysis={aiAnalysis ?? { summary: '', topics: [], suggestedQuestions: [] }}
+                      isLoading={isAiLoading || !aiAnalysis}
+                    />
+                  </Suspense>
                 </div>
               )}
             </div>

--- a/components/DownloadSection.tsx
+++ b/components/DownloadSection.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { VideoMetadata } from '../types';
-import { Download, FileVideo, Music, Image as ImageIcon, Check, Loader2, ExternalLink, AlertCircle, ShieldCheck } from 'lucide-react';
+import { Download, FileVideo, Music, Image as ImageIcon, Loader2, AlertCircle, ShieldCheck } from 'lucide-react';
 import { extractVideoId } from '../services/youtubeService';
 import { processDownload, downloadBlob } from '../services/downloadService';
 
@@ -17,7 +17,7 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
 
   const videoId = extractVideoId(metadata.url);
 
-  const downloadFormats = {
+  const downloadFormats = useMemo(() => ({
     video: [
       { label: '1080p', ext: 'mp4', sub: 'High Definition', icon: FileVideo, quality: '1080p' },
       { label: '720p', ext: 'mp4', sub: 'HD Ready', icon: FileVideo, quality: '720p' },
@@ -30,9 +30,9 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
       { label: 'Max Res', ext: 'jpg', sub: '1920x1080', icon: ImageIcon, url: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg` },
       { label: 'High Quality', ext: 'jpg', sub: '480x360', icon: ImageIcon, url: `https://img.youtube.com/vi/${videoId}/hqdefault.jpg` },
     ]
-  };
+  }), [videoId]);
 
-  const handleDownload = async (item: any) => {
+  const handleDownload = async (item: { label: string; quality?: string; url?: string; }) => {
     setProcessing(item.label);
     setError(null);
     
@@ -54,7 +54,7 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
       }
 
       // 2. Handle Video/Audio
-      const result = await processDownload(metadata.url, activeTab as 'video' | 'audio', item.quality);
+      const result = await processDownload(metadata.url, activeTab as 'video' | 'audio', item.quality ?? '1080p', metadata.title);
       
       if (result.success && result.url) {
         const safeTitle = metadata.title.replace(/[\\/*?:"<>|]/g, '').trim().slice(0, 60) || 'download';


### PR DESCRIPTION
### Motivation
- Fix fragile client-side fallback links that expire or are blocked and cause "File wasn’t available on site" by serving fallback media from the app's origin.
- Reduce user-perceived waiting when the backend `yt-dlp` probe succeeds but cannot produce a stream by shortening the probe timeout.
- Improve frontend startup and UX by lazy-loading AI features and reduce unnecessary re-renders in the download panel.

### Description
- Added a server-side Cobalt resolver (`resolve_with_cobalt`) and a new `/fallback-download` endpoint that accepts `url`, `type`, `quality`, optional `title`, and `probe`, and either returns probe metadata or streams the mirrored media as a same-origin attachment with stable filename and `Cache-Control: no-store`. (`main.py`)
- Hardened server streaming with `stream_proxy` to include a `User-Agent` header and a 20s request timeout to avoid silent failures when proxying third-party URLs. (`main.py`)
- Reduced the frontend backend probe timeout from 8s to 4.5s and changed `processDownload` to accept an optional `title` parameter and to return a same-origin `/fallback-download` URL immediately when the backend cannot fetch the media. This avoids sending fragile third-party URLs to the browser. (`services/downloadService.ts`)
- Passed the video title from the UI into `processDownload`, memoized `downloadFormats` with `useMemo`, tightened `handleDownload` typing, and ensured filename logic uses the provided title for consistent downloads. (`components/DownloadSection.tsx`)
- Lazy-loaded the AI UI (`AiInsights`) via `React.lazy` and dynamically import `analyzeVideoContext` only when AI is requested, wrapped in `Suspense` with a loader. (`App.tsx`)

### Testing
- Built the frontend with `npm run build` successfully and produced a separate `AiInsights` chunk (build completed without errors). 
- Verified Python server file compiles with `python -m py_compile main.py` with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f1a2d5048327baa0f4f537ae853c)