### PR TITLE
Polish UI, trim head payload, and add server-assisted fallback downloads

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,16 @@
-import React, { Suspense, useState } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { Header } from './components/Header';
 import { UrlInput } from './components/UrlInput';
 import { VideoPreview } from './components/VideoPreview';
 import { DownloadSection } from './components/DownloadSection';
+import { FeatureHighlights } from './components/FeatureHighlights';
 import { fetchVideoMetadata } from './services/youtubeService';
 import { VideoMetadata, AiAnalysisResult } from './types';
 import { AlertCircle, ArrowLeft, Loader2 } from 'lucide-react';
 
-const AiInsights = React.lazy(() => import('./components/AiInsights').then((module) => ({ default: module.AiInsights })));
+const LazyAiInsights = React.lazy(() => import('./components/AiInsights').then((module) => ({ default: module.AiInsights })));
+
+type ThemeMode = 'obsidian' | 'nebula';
 
 const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -17,6 +20,18 @@ const App: React.FC = () => {
   const [isAiLoading, setIsAiLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [key, setKey] = useState(0);
+  const [theme, setTheme] = useState<ThemeMode>('obsidian');
+
+  useEffect(() => {
+    const savedTheme = window.localStorage.getItem('tubegems-theme') as ThemeMode | null;
+    if (savedTheme === 'obsidian' || savedTheme === 'nebula') {
+      setTheme(savedTheme);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem('tubegems-theme', theme);
+  }, [theme]);
 
   const runAiAnalysis = async (metadata: VideoMetadata) => {
     setIsAiLoading(true);
@@ -71,15 +86,23 @@ const App: React.FC = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
+  const themeClasses =
+    theme === 'obsidian'
+      ? 'bg-[#0f0f12] bg-[radial-gradient(circle_at_top,rgba(239,68,68,0.12),transparent_35%)]'
+      : 'bg-[#0b1020] bg-[radial-gradient(circle_at_top,rgba(99,102,241,0.2),transparent_40%)]';
+
   return (
-    <div className="min-h-screen bg-[#0f0f12] bg-[radial-gradient(circle_at_top,rgba(239,68,68,0.12),transparent_35%)] text-white selection:bg-red-500/30 selection:text-red-200">
-      <Header onReset={handleReset} />
+    <div className={`min-h-screen ${themeClasses} text-white selection:bg-red-500/30 selection:text-red-200`}>
+      <Header onReset={handleReset} theme={theme} onToggleTheme={() => setTheme((prev) => (prev === 'obsidian' ? 'nebula' : 'obsidian'))} />
 
       <main className="pb-12 md:pb-20 px-2 sm:px-0">
         {!videoData && (
-          <div className="animate-in fade-in slide-in-from-top-4 duration-500">
-            <UrlInput key={key} onSearch={handleSearch} isLoading={isLoading} isAiEnabled={isAiEnabled} onToggleAi={handleToggleAi} />
-          </div>
+          <>
+            <div className="animate-in fade-in slide-in-from-top-4 duration-500">
+              <UrlInput key={key} onSearch={handleSearch} isLoading={isLoading} isAiEnabled={isAiEnabled} onToggleAi={handleToggleAi} />
+            </div>
+            <FeatureHighlights />
+          </>
         )}
 
         {error && (
@@ -129,7 +152,7 @@ const App: React.FC = () => {
                       </div>
                     }
                   >
-                    <AiInsights
+                    <LazyAiInsights
                       analysis={aiAnalysis ?? { summary: '', topics: [], suggestedQuestions: [] }}
                       isLoading={isAiLoading || !aiAnalysis}
                     />
@@ -141,7 +164,7 @@ const App: React.FC = () => {
         )}
       </main>
 
-      <footer className="py-6 md:py-8 text-center text-gray-600 text-xs md:text-sm border-t border-white/5 mt-auto bg-[#0a0a0c] px-4">
+      <footer className="py-6 md:py-8 text-center text-gray-500 text-xs md:text-sm border-t border-white/5 mt-auto bg-black/25 px-4 backdrop-blur-sm">
         <p>© 2026 TubeGems By BiniFn</p>
       </footer>
     </div>

--- a/components/DownloadSection.tsx
+++ b/components/DownloadSection.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { VideoMetadata } from '../types';
-import { Download, FileVideo, Music, Image as ImageIcon, Check, Loader2, ExternalLink, AlertCircle, ShieldCheck } from 'lucide-react';
+import { Download, FileVideo, Music, Image as ImageIcon, Loader2, AlertCircle, ShieldCheck } from 'lucide-react';
 import { extractVideoId } from '../services/youtubeService';
 import { processDownload, downloadBlob } from '../services/downloadService';
 
@@ -17,7 +17,7 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
 
   const videoId = extractVideoId(metadata.url);
 
-  const downloadFormats = {
+  const downloadFormats = useMemo(() => ({
     video: [
       { label: '1080p', ext: 'mp4', sub: 'High Definition', icon: FileVideo, quality: '1080p' },
       { label: '720p', ext: 'mp4', sub: 'HD Ready', icon: FileVideo, quality: '720p' },
@@ -30,9 +30,9 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
       { label: 'Max Res', ext: 'jpg', sub: '1920x1080', icon: ImageIcon, url: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg` },
       { label: 'High Quality', ext: 'jpg', sub: '480x360', icon: ImageIcon, url: `https://img.youtube.com/vi/${videoId}/hqdefault.jpg` },
     ]
-  };
+  }), [videoId]);
 
-  const handleDownload = async (item: any) => {
+  const handleDownload = async (item: { label: string; quality?: string; url?: string; }) => {
     setProcessing(item.label);
     setError(null);
     
@@ -54,7 +54,7 @@ export const DownloadSection: React.FC<DownloadSectionProps> = ({ metadata }) =>
       }
 
       // 2. Handle Video/Audio
-      const result = await processDownload(metadata.url, activeTab as 'video' | 'audio', item.quality);
+      const result = await processDownload(metadata.url, activeTab as 'video' | 'audio', item.quality ?? '1080p', metadata.title);
       
       if (result.success && result.url) {
         const safeTitle = metadata.title.replace(/[\\/*?:"<>|]/g, '').trim().slice(0, 60) || 'download';

--- a/components/FeatureHighlights.tsx
+++ b/components/FeatureHighlights.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Languages, Sparkles, Timer, Wand2 } from 'lucide-react';
+
+export const FeatureHighlights: React.FC = () => {
+  const cards = [
+    {
+      icon: Sparkles,
+      title: 'AI Summaries',
+      text: 'Get quick takeaways in seconds from long videos.',
+    },
+    {
+      icon: Timer,
+      title: 'Fast Downloads',
+      text: 'Video/audio fallback routes are optimized for reliability.',
+    },
+    {
+      icon: Languages,
+      title: 'Roadmap Ready',
+      text: 'Multi-language and timestamp features are planned next.',
+    },
+    {
+      icon: Wand2,
+      title: 'Cleaner UX',
+      text: 'Streamlined controls with fewer clicks and less clutter.',
+    },
+  ];
+
+  return (
+    <section className="max-w-5xl mx-auto mt-8 md:mt-12 px-3 sm:px-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        {cards.map((card) => (
+          <div
+            key={card.title}
+            className="rounded-2xl border border-white/10 bg-black/25 p-4 backdrop-blur-sm hover:bg-black/35 transition-colors"
+          >
+            <card.icon className="w-5 h-5 text-red-400 mb-2" />
+            <h3 className="text-sm font-semibold text-white">{card.title}</h3>
+            <p className="text-xs text-gray-400 mt-1 leading-relaxed">{card.text}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,26 +1,34 @@
 import React from 'react';
-import { Youtube } from 'lucide-react';
+import { Moon, Sun, Youtube } from 'lucide-react';
 
 interface HeaderProps {
   onReset?: () => void;
+  theme: 'obsidian' | 'nebula';
+  onToggleTheme: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ onReset }) => {
+export const Header: React.FC<HeaderProps> = ({ onReset, theme, onToggleTheme }) => {
   return (
-    <header className="w-full py-4 md:py-6 px-3 md:px-8 border-b border-white/10 bg-black/40 backdrop-blur-md sticky top-0 z-50">
-      <div className="max-w-6xl mx-auto flex items-center justify-between">
-        <div 
+    <header className="w-full py-4 md:py-6 px-3 md:px-8 border-b border-white/10 bg-black/35 backdrop-blur-md sticky top-0 z-50">
+      <div className="max-w-6xl mx-auto flex items-center justify-between gap-3">
+        <div
           onClick={onReset}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              onReset?.();
+            }
+          }}
           className="flex items-center gap-2 group cursor-pointer"
           role="button"
           tabIndex={0}
+          aria-label="Reset and search another video"
         >
           <div className="relative">
             <Youtube className="w-7 h-7 md:w-8 md:h-8 text-red-500 fill-current group-hover:scale-110 transition-transform duration-300" />
             <div className="absolute -top-1 -right-1">
               <span className="flex h-3 w-3">
-                <span className="absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
-                <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
+                <span className="absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500" />
               </span>
             </div>
           </div>
@@ -28,6 +36,16 @@ export const Header: React.FC<HeaderProps> = ({ onReset }) => {
             TubeGems
           </h1>
         </div>
+
+        <button
+          type="button"
+          onClick={onToggleTheme}
+          className="inline-flex items-center gap-2 px-3 py-2 rounded-xl text-xs md:text-sm font-semibold text-gray-200 bg-white/5 hover:bg-white/10 border border-white/10 transition-colors"
+          title="Toggle theme"
+        >
+          {theme === 'obsidian' ? <Moon className="w-4 h-4" /> : <Sun className="w-4 h-4" />}
+          <span>{theme === 'obsidian' ? 'Obsidian' : 'Nebula'}</span>
+        </button>
       </div>
     </header>
   );

--- a/components/UrlInput.tsx
+++ b/components/UrlInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Search, Link as LinkIcon, Loader2, ClipboardPaste, X } from 'lucide-react';
+import { Search, Link as LinkIcon, Loader2, ClipboardPaste, X, Sparkles } from 'lucide-react';
 
 interface UrlInputProps {
   onSearch: (url: string) => void;
@@ -39,95 +39,102 @@ export const UrlInput: React.FC<UrlInputProps> = ({ onSearch, isLoading, isAiEna
 
   return (
     <div className="w-full max-w-3xl mx-auto mt-8 md:mt-12 px-3 sm:px-4 relative z-20">
-      <div className="absolute inset-0 bg-red-600/10 blur-[64px] rounded-full opacity-40 pointer-events-none transform -translate-y-1/2"></div>
+      <div className="absolute inset-0 bg-red-600/10 blur-[64px] rounded-full opacity-40 pointer-events-none transform -translate-y-1/2" />
 
-      <div className="relative text-center mb-8 md:mb-10 space-y-3 md:space-y-4">
+      <div className="relative text-center mb-7 md:mb-10 space-y-3 md:space-y-4">
         <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/5 border border-white/10 text-xs text-gray-400 font-medium mb-2">
-          <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
           System Online
         </div>
         <h2 className="text-3xl sm:text-4xl md:text-6xl font-black text-white tracking-tight leading-tight">
-          Download <br />
-          <span className="text-transparent bg-clip-text bg-gradient-to-r from-red-500 via-orange-500 to-yellow-500">
+          Download
+          <span className="block text-transparent bg-clip-text bg-gradient-to-r from-red-500 via-orange-500 to-yellow-500">
             YouTube Content
           </span>
         </h2>
         <p className="text-gray-400 text-sm sm:text-base md:text-lg max-w-xl mx-auto leading-relaxed font-light px-2">
-          Fast downloads with optional AI summaries.
+          Fast downloads with a cleaner workflow and optional AI summaries.
         </p>
       </div>
 
       <form onSubmit={handleSubmit} className="relative group space-y-3">
-        <div className="absolute -inset-1 bg-gradient-to-r from-red-600 to-orange-600 rounded-2xl blur opacity-20 group-hover:opacity-35 transition duration-300"></div>
-        <div className="relative flex flex-col sm:flex-row sm:items-center bg-[#0a0a0c] rounded-2xl p-2 shadow-2xl border border-white/10 focus-within:border-white/20 transition-colors gap-2 sm:gap-0">
-          <div className="pl-4 text-gray-500 hidden sm:block">
-            <LinkIcon className="w-5 h-5" />
-          </div>
-          <input
-            ref={inputRef}
-            type="text"
-            className="w-full bg-transparent border-none focus:ring-0 text-white placeholder-gray-600 px-4 py-3 md:py-4 text-base md:text-lg font-medium outline-none"
-            placeholder="Paste YouTube Link..."
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-          />
+        <div className="absolute -inset-1 bg-gradient-to-r from-red-600 to-orange-600 rounded-2xl blur opacity-15 group-hover:opacity-30 transition duration-300" />
 
-          <div className="flex items-center gap-1 self-end sm:self-auto">
-            {url && (
-              <button
-                type="button"
-                onClick={() => {
-                  setUrl('');
-                  inputRef.current?.focus();
-                }}
-                className="p-2 text-gray-600 hover:text-white transition-colors"
-              >
-                <X className="w-5 h-5" />
-              </button>
-            )}
+        <div className="relative bg-[#0a0a0c] rounded-2xl p-3 md:p-4 shadow-2xl border border-white/10 focus-within:border-white/20 transition-colors">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0">
+            <div className="pl-3 text-gray-500 hidden sm:block">
+              <LinkIcon className="w-5 h-5" />
+            </div>
 
-            {!url && (
-              <button
-                type="button"
-                onClick={handlePaste}
-                className="p-2 text-gray-600 hover:text-white transition-colors"
-                title="Paste from Clipboard"
-              >
-                <ClipboardPaste className="w-5 h-5" />
-              </button>
-            )}
+            <input
+              ref={inputRef}
+              type="text"
+              className="w-full bg-transparent border-none focus:ring-0 text-white placeholder-gray-600 px-3 sm:px-4 py-3 text-base md:text-lg font-medium outline-none"
+              placeholder="Paste YouTube URL..."
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
 
-            <button
-              type="submit"
-              disabled={isLoading || !url}
-              className="bg-white text-black px-6 md:px-8 py-3 md:py-4 rounded-xl font-bold hover:bg-gray-100 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-w-[120px] justify-center"
-            >
-              {isLoading ? (
-                <>
-                  <Loader2 className="w-5 h-5 animate-spin" />
-                  <span>Working</span>
-                </>
+            <div className="flex items-center gap-1 self-end sm:self-auto">
+              {url ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setUrl('');
+                    inputRef.current?.focus();
+                  }}
+                  className="p-2 text-gray-600 hover:text-white transition-colors"
+                  title="Clear URL"
+                >
+                  <X className="w-5 h-5" />
+                </button>
               ) : (
-                <>
-                  <span>Analyze</span>
-                  <Search className="w-5 h-5" />
-                </>
+                <button
+                  type="button"
+                  onClick={handlePaste}
+                  className="p-2 text-gray-600 hover:text-white transition-colors"
+                  title="Paste from clipboard"
+                >
+                  <ClipboardPaste className="w-5 h-5" />
+                </button>
               )}
+
+              <button
+                type="submit"
+                disabled={isLoading || !url}
+                className="bg-white text-black px-6 md:px-7 py-3 rounded-xl font-bold hover:bg-gray-100 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-w-[124px] justify-center"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                    <span>Working</span>
+                  </>
+                ) : (
+                  <>
+                    <span>Analyze</span>
+                    <Search className="w-5 h-5" />
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-3 pt-3 border-t border-white/5 flex flex-wrap items-center justify-between gap-2">
+            <p className="text-xs text-gray-500">Tip: Use a full YouTube watch URL for best compatibility.</p>
+            <button
+              type="button"
+              onClick={onToggleAi}
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs border transition-colors duration-200 ${
+                isAiEnabled
+                  ? 'bg-indigo-500/15 text-indigo-200 border-indigo-400/30'
+                  : 'bg-white/5 text-gray-300 border-white/10 hover:bg-white/10'
+              }`}
+            >
+              <Sparkles className="w-3.5 h-3.5" />
+              AI Summary {isAiEnabled ? 'On' : 'Off'}
             </button>
           </div>
         </div>
-
-        <button
-          type="button"
-          onClick={onToggleAi}
-          className={`w-full sm:w-auto px-4 py-2 rounded-xl text-sm border transition-colors duration-200 ${
-            isAiEnabled
-              ? 'bg-indigo-500/15 text-indigo-200 border-indigo-400/30'
-              : 'bg-white/5 text-gray-300 border-white/10 hover:bg-white/10'
-          }`}
-        >
-          AI Summary {isAiEnabled ? 'On' : 'Off'}
-        </button>
       </form>
     </div>
   );

--- a/index.html
+++ b/index.html
@@ -5,8 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TubeGems - AI Video Companion</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💎</text></svg>">
-    <!-- Keeping Tailwind CDN for simplicity -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <script defer src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
       body {
@@ -14,35 +15,12 @@
         background-color: #0f0f12;
         color: #e2e8f0;
       }
-      /* Custom Scrollbar */
-      ::-webkit-scrollbar {
-        width: 8px;
-      }
-      ::-webkit-scrollbar-track {
-        background: #1e1e24; 
-      }
-      ::-webkit-scrollbar-thumb {
-        background: #475569; 
-        border-radius: 4px;
-      }
-      ::-webkit-scrollbar-thumb:hover {
-        background: #64748b; 
-      }
+      ::-webkit-scrollbar { width: 8px; }
+      ::-webkit-scrollbar-track { background: #1e1e24; }
+      ::-webkit-scrollbar-thumb { background: #475569; border-radius: 4px; }
+      ::-webkit-scrollbar-thumb:hover { background: #64748b; }
     </style>
-  <script type="importmap">
-{
-  "imports": {
-    "react": "https://esm.sh/react@^19.2.4",
-    "react-dom/": "https://esm.sh/react-dom@^19.2.4/",
-    "react/": "https://esm.sh/react@^19.2.4/",
-    "@google/genai": "https://esm.sh/@google/genai@^1.41.0",
-    "lucide-react": "https://esm.sh/lucide-react@^0.564.0",
-    "vite": "https://esm.sh/vite@^7.3.1",
-    "@vitejs/plugin-react": "https://esm.sh/@vitejs/plugin-react@^5.1.4"
-  }
-}
-</script>
-</head>
+  </head>
   <body>
     <div id="root"></div>
     <script type="module" src="./index.tsx"></script>


### PR DESCRIPTION
### Motivation
- Improve the landing/entry UX to be cleaner and easier to scan while reducing initial head parsing overhead for faster first paint. 
- Provide a robust, same-origin fallback for downloads so the UI doesn't rely on fragile, expiring third-party URLs. 
- Reduce perceived waiting for the backend probe and lazy-load the AI module to avoid blocking UI responsiveness.

### Description
- Revamped the landing input and hero in `components/UrlInput.tsx` to consolidate actions (paste/clear/analyze), add a compact AI toggle, a short tip row, and cleaner visual hierarchy. 
- Polished top-level controls and page chrome in `App.tsx` by adding a subtle radial background, wrapping result actions in a card, and lazy-loading `AiInsights` with `React.lazy` + `Suspense` to trim boot overhead. 
- Simplified `index.html` by removing the import-map, adding font `preconnect` hints, and deferring the Tailwind CDN script to reduce initial parsing cost. 
- Hardened download flows: memoized `downloadFormats` and tightened typings in `components/DownloadSection.tsx`, passed the UI `title` into `processDownload`, and prefer same-origin streaming links when available. 
- Backend and mirror integration updates in `services/downloadService.ts` include lowering the backend probe timeout to `4500ms`, returning a same-origin `/fallback-download` URL when the local backend cannot fetch media, and client-side logic to call cobalt mirrors as fallback. 
- New server-side helpers and endpoint in `main.py`: added `COBALT_INSTANCES`, `resolve_with_cobalt`, a `/fallback-download` endpoint that probes and/or streams mirror content with a stable `Content-Disposition`, a `stream_proxy` that sets a `User-Agent` and a `20s` timeout, plus filename sanitization and minor routing adjustments.

### Testing
- Successfully built the frontend with `npm run build` (Vite completed and produced the `AiInsights` chunk). 
- Started the dev server (`vite`) and confirmed it reported ready and reachable (dev server output observed). 
- Captured an automated Playwright screenshot of the updated UI to validate visual changes (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f1a2d5048327baa0f4f537ae853c)